### PR TITLE
Make training take ~1 second

### DIFF
--- a/persam_f.py
+++ b/persam_f.py
@@ -131,7 +131,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, args.train_epoch)
 
     # Run the decoder
-    masks, scores, logits, logits_high = predictor.predict(
+    masks, scores, logits, original_logits_high = predictor.predict(
         point_coords=topk_xy,
         point_labels=topk_label,
         multimask_output=True)

--- a/persam_f.py
+++ b/persam_f.py
@@ -51,6 +51,7 @@ def main():
         if ".DS" not in obj_name:
             persam_f(args, obj_name, images_path, masks_path, output_path)
 
+sam = None
 
 def persam_f(args, obj_name, images_path, masks_path, output_path):
     
@@ -78,14 +79,16 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
     gt_mask = gt_mask.flatten(1).cuda()
     
     print("======> Load SAM" )
-    if args.sam_type == 'vit_h':
-        sam_type, sam_ckpt = 'vit_h', 'sam_vit_h_4b8939.pth'
-        sam = sam_model_registry[sam_type](checkpoint=sam_ckpt).cuda()
-    elif args.sam_type == 'vit_t':
-        sam_type, sam_ckpt = 'vit_t', 'weights/mobile_sam.pt'
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        sam = sam_model_registry[sam_type](checkpoint=sam_ckpt).to(device=device)
-        sam.eval()
+    global sam
+    if sam is None:
+      if args.sam_type == 'vit_h':
+          sam_type, sam_ckpt = 'vit_h', 'sam_vit_h_4b8939.pth'
+          sam = sam_model_registry[sam_type](checkpoint=sam_ckpt).cuda()
+      elif args.sam_type == 'vit_t':
+          sam_type, sam_ckpt = 'vit_t', 'weights/mobile_sam.pt'
+          device = "cuda" if torch.cuda.is_available() else "cpu"
+          sam = sam_model_registry[sam_type](checkpoint=sam_ckpt).to(device=device)
+          sam.eval()
     
     
     for name, param in sam.named_parameters():
@@ -123,6 +126,8 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
 
     # Positive location prior
     topk_xy, topk_label = point_selection(sim, topk=1)
+
+
 
 
     print('======> Start Training')

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -96,7 +96,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
 
             resolution = [256, 256]
 
-            gt_mask = torch.tensor(ref_mask)[:, :, 0] > 0 
+            gt_mask = torch.tensor(ref_mask)[None,:, :, 0] > 0 
             gt_mask = TVF.resize(gt_mask.float(), resolution)
             gt_mask = gt_mask.unsqueeze(0).flatten(1).cuda()
             

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -199,7 +199,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
             topk_xy, topk_label = point_selection(sim, topk=1)
 
             # First-step prediction
-            masks, scores, logits, logits_high = predictor.predict(
+            masks, scores, logits, original_logits_high = predictor.predict(
                         point_coords=topk_xy,
                         point_labels=topk_label,
                         multimask_output=True)

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -131,20 +131,19 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
             mask_weights.train()
             
             optimizer = torch.optim.AdamW(mask_weights.parameters(), lr=args.lr, eps=1e-4)
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, args.train_epoch_inside)
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, args.train_epoch)
 
-            for train_idx in range(args.train_epoch_inside):
+            # Run the decoder
+            masks, scores, logits, logits_high = predictor.predict(
+                point_coords=topk_xy,
+                point_labels=topk_label,
+                multimask_output=True)
+            original_logits_high = original_logits_high.flatten(1)
 
-                # Run the decoder
-                masks, scores, logits, logits_high = predictor.predict(
-                    point_coords=topk_xy,
-                    point_labels=topk_label,
-                    multimask_output=True)
-                logits_high = logits_high.flatten(1)
-
+            for train_idx in range(args.train_epoch):
                 # Weighted sum three-scale masks
                 weights = torch.cat((1 - mask_weights.weights.sum(0).unsqueeze(0), mask_weights.weights), dim=0)
-                logits_high = logits_high * weights
+                logits_high = original_logits_high * weights
                 logits_high = logits_high.sum(0).unsqueeze(0)
 
                 dice_loss = calculate_dice_loss(logits_high, gt_mask)

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -207,7 +207,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
             topk_xy, topk_label = point_selection(sim, topk=1)
 
             # First-step prediction
-            masks, scores, logits, original_logits_high = predictor.predict(
+            masks, scores, logits, logits_high = predictor.predict(
                         point_coords=topk_xy,
                         point_labels=topk_label,
                         multimask_output=True)

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -138,7 +138,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
             mask_weights.train()
             
             optimizer = torch.optim.AdamW(mask_weights.parameters(), lr=args.lr, eps=1e-4)
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, args.train_epoch)
+            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, args.train_epoch_inside)
 
             # Run the decoder
             masks, scores, logits, original_logits_high = predictor.predict(

--- a/persam_f_multi_obj.py
+++ b/persam_f_multi_obj.py
@@ -148,7 +148,7 @@ def persam_f(args, obj_name, images_path, masks_path, output_path):
             original_logits_high = TVF.resize(original_logits_high,resolution)
             original_logits_high = original_logits_high.flatten(1)
 
-            for train_idx in range(args.train_epoch):
+            for train_idx in range(args.train_epoch_inside):
                 # Weighted sum three-scale masks
                 weights = torch.cat((1 - mask_weights.weights.sum(0).unsqueeze(0), mask_weights.weights), dim=0)
                 logits_high = original_logits_high * weights

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 warnings
 argparse
 opencv-python
+torchvision


### PR DESCRIPTION
# Changes

The core training loop of PerSAM_f does a lot of unnecessary computation.
It evaluates the SAM mask detector once every epoch, but this step can be precomputed.
I modified the training loop to precompute this step.

Also, the current training loop uses large mask images are extremely high-resolution (some are 1280x1280 pixels).
I downsampled these to 256x256 pixels.

On Google Colab with a T4, these two changes **decreased training time from ~9s to ~1s**.

Currently, the PerSAM_f script loads the full SAM model for every image it personalizes.
On Google Colab with a T4, this adds 8-15 seconds to the "training" time.
I modified the script to use a global SAM model, which it only loads once.

I have applied these same changes to `persam_f_multi_obj.py`. It seems to work, but I haven't put much focus on this, and I haven't evaluated its results.

# Evaluation

Evaluation results are **nearly identical** on PerSeg.

Original:
```
Commit d4b42a8:
Args: Namespace(pred_path='persam_f', gt_path='./data/Annotations', ref_idx='00') 
backpack_dog, IoU: 95.76, Acc: 95.80
clock, IoU: 94.79, Acc: 94.84
colorful_teapot, IoU: 84.47, Acc: 84.67
dog3, IoU: 88.67, Acc: 93.88
duck_toy, IoU: 97.31, Acc: 97.31
fancy_boot, IoU: 95.96, Acc: 96.05
rc_car, IoU: 96.12, Acc: 96.25
round_bird, IoU: 96.85, Acc: 97.00
table, IoU: 94.66, Acc: 95.02
teddybear, IoU: 94.61, Acc: 96.23
wolf_plushie, IoU: 94.32, Acc: 95.74
```
Modified:
```
Commit f517cfd:
Args: Namespace(pred_path='persam_f', gt_path='./data/Annotations', ref_idx='00') 
backpack, IoU: 96.66, Acc: 96.77
backpack_dog, IoU: 95.76, Acc: 95.80
cat, IoU: 95.51, Acc: 95.87
cat2, IoU: 93.69, Acc: 93.77
cat_statue, IoU: 95.43, Acc: 96.17
chair, IoU: 92.14, Acc: 92.16
colorful_teapot, IoU: 84.84, Acc: 85.05
dog, IoU: 96.81, Acc: 96.87
dog4, IoU: 95.18, Acc: 95.43
dog6, IoU: 94.85, Acc: 95.00
dog7, IoU: 93.77, Acc: 94.11
duck_toy, IoU: 97.31, Acc: 97.31
fancy_boot, IoU: 95.96, Acc: 96.05
grey_sloth_plushie, IoU: 96.64, Acc: 96.71
monster_toy, IoU: 94.21, Acc: 94.28
table, IoU: 94.66, Acc: 95.02
teapot, IoU: 96.93, Acc: 97.19
teddybear, IoU: 94.61, Acc: 96.23
wolf_plushie, IoU: 94.32, Acc: 95.74
```
You can find the eval notebook in Colab [here](https://colab.research.google.com/drive/19IgIgOYInNyUxoFJJecD7kdPbUBwA4qg?usp=sharing).

> **Note**
> The Colab environment runs OOM partway through both eval runs, causing some subjects in PerSeg not to be shown here.
> This OOM error happens both before and after my proposed changes.

